### PR TITLE
Save team data to db, set up initial scaffolding for processing individual box score data

### DIFF
--- a/cmd/gamestatsjob/main.go
+++ b/cmd/gamestatsjob/main.go
@@ -1,51 +1,14 @@
 package main
 
 import (
-	"encoding/json"
 	"log"
-	"os"
 
-	"github.com/rajwalgautam/nba-stats/internal/pkg/db"
-	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
+	"github.com/rajwalgautam/nba-stats/internal/pkg/gamestatsjob"
 )
 
 func main() {
-	// init db
-	db, err := db.New()
+	err := gamestatsjob.Run()
 	if err != nil {
-		log.Fatalf("db connection err: %v", err)
-	}
-	err = db.Init()
-	if err != nil {
-		log.Fatalf("db init err: %v", err)
-	}
-	log.Println("db initialized successfully")
-
-	// init stats client
-	apiKey, ok := os.LookupEnv("SPORTSBLAZE_API_KEY")
-	if !ok {
-		log.Fatal("error: sportsblaze api key required")
-	}
-	statsClient := sportsblaze.New(sportsblaze.Options{ApiKey: apiKey})
-
-	// fetch daily box scores
-	date := "2024-10-24"
-	dailyBoxScores, err := statsClient.DailyBoxScores(date)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Printf("got %d games for %s\n", len(dailyBoxScores.Games), date)
-
-	boxScoresOutputFn, ok := os.LookupEnv("BOX_SCORES_OUTPUT_FILENAME")
-	if ok {
-		// write to file
-		b, err := json.MarshalIndent(dailyBoxScores, "", "	")
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = os.WriteFile(boxScoresOutputFn, b, 0644)
-		if err != nil {
-			log.Fatal(err)
-		}
+		log.Fatalf("error running gamestatsjob: %v", err)
 	}
 }

--- a/cmd/gamestatsjob/main.go
+++ b/cmd/gamestatsjob/main.go
@@ -1,14 +1,50 @@
 package main
 
 import (
+	"fmt"
 	"log"
 
+	"github.com/rajwalgautam/nba-stats/internal/pkg/db"
 	"github.com/rajwalgautam/nba-stats/internal/pkg/gamestatsjob"
+	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
 )
 
 func main() {
-	err := gamestatsjob.Run()
+	db, err := initDb()
+	if err != nil {
+		log.Fatalf("error initializing db: %v", err)
+	}
+	log.Println("db initialized successfully")
+
+	statsClient, err := initStatsClient()
+	if err != nil {
+		log.Fatalf("error initializing stats client: %v", err)
+	}
+	log.Println("stats client initialized successfully")
+
+	err = gamestatsjob.Run(db, statsClient)
 	if err != nil {
 		log.Fatalf("error running gamestatsjob: %v", err)
 	}
+}
+
+func initDb() (*db.DB, error) {
+	statsdb, err := db.New()
+	if err != nil {
+		return nil, fmt.Errorf("db connection err: %v", err)
+	}
+	err = statsdb.Init()
+	if err != nil {
+		return nil, fmt.Errorf("db init err: %v", err)
+	}
+	return statsdb, nil
+}
+
+func initStatsClient() (*sportsblaze.Client, error) {
+	// apiKey, ok := os.LookupEnv("SPORTSBLAZE_API_KEY")
+	// if !ok {
+	// 	return nil, errors.New("error: sportsblaze api key required")
+	// }
+	apiKey := "sbf1zukz3ya0hsyvyfjb06e"
+	return sportsblaze.New(sportsblaze.Options{ApiKey: apiKey}), nil
 }

--- a/cmd/gamestatsjob/main.go
+++ b/cmd/gamestatsjob/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/rajwalgautam/nba-stats/internal/pkg/db"
 	"github.com/rajwalgautam/nba-stats/internal/pkg/gamestatsjob"
@@ -41,10 +43,9 @@ func initDb() (*db.DB, error) {
 }
 
 func initStatsClient() (*sportsblaze.Client, error) {
-	// apiKey, ok := os.LookupEnv("SPORTSBLAZE_API_KEY")
-	// if !ok {
-	// 	return nil, errors.New("error: sportsblaze api key required")
-	// }
-	apiKey := "sbf1zukz3ya0hsyvyfjb06e"
+	apiKey, ok := os.LookupEnv("SPORTSBLAZE_API_KEY")
+	if !ok {
+		return nil, errors.New("error: sportsblaze api key required")
+	}
 	return sportsblaze.New(sportsblaze.Options{ApiKey: apiKey}), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -57,14 +57,11 @@ func (db *DB) CreateTables() error {
 }
 
 func (db *DB) SaveTeam(team sportsblaze.Team) error {
-	teamBytes, err := json.Marshal(Team{
-		FullName:     team.Name,
-		Abbreviation: "somevalue", // TODO: get abbreviation
-	})
+	bytes, err := json.Marshal(transformTeamToDBTeam(team))
 	if err != nil {
 		return fmt.Errorf("error marshalling team %s: %w", team.Name, err)
 	}
-	return db.set(nbaTeamsTable.name, team.ID, teamBytes)
+	return db.set(nbaTeamsTable.name, team.ID, bytes)
 }
 
 func (db *DB) set(table string, key string, value []byte) error {

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -2,12 +2,12 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"log"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
 )
 
 type DB struct {
@@ -15,7 +15,8 @@ type DB struct {
 }
 
 func New() (*DB, error) {
-	connStr := createConnectionString(os.Getenv("POSTGRES_USER"), os.Getenv("POSTGRES_PASSWORD"), os.Getenv("POSTGRES_HOST"), os.Getenv("POSTGRES_PORT"), os.Getenv("POSTGRES_DB"))
+	// connStr := createConnectionString(os.Getenv("POSTGRES_USER"), os.Getenv("POSTGRES_PASSWORD"), os.Getenv("POSTGRES_HOST"), os.Getenv("POSTGRES_PORT"), os.Getenv("POSTGRES_DB"))
+	connStr := createConnectionString("nbastatsuser", "nbastatspassword", "localhost", "30001", "nba_stats")
 	ctx := context.Background()
 
 	// Create connection pool
@@ -52,7 +53,26 @@ func (db *DB) CreateTables() error {
 			return fmt.Errorf("error creating gamestats tables.\nstatement: %v\nerror: %w", s, err)
 		}
 	}
-	log.Println("Successfully created gamestats tables")
+	return nil
+}
+
+func (db *DB) SaveTeam(team sportsblaze.Team) error {
+	teamBytes, err := json.Marshal(Team{
+		FullName:     team.Name,
+		Abbreviation: "somevalue", // TODO: get abbreviation
+	})
+	if err != nil {
+		return fmt.Errorf("error marshalling team %s: %w", team.Name, err)
+	}
+	return db.set(nbaTeamsTable.name, team.ID, teamBytes)
+}
+
+func (db *DB) set(table string, key string, value []byte) error {
+	sql := fmt.Sprintf(setSql, table)
+	_, err := db.conn.Exec(context.Background(), sql, key, value)
+	if err != nil {
+		return fmt.Errorf("error setting value in table %s for key %s: %w", table, key, err)
+	}
 	return nil
 }
 

--- a/internal/pkg/db/db.go
+++ b/internal/pkg/db/db.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -15,8 +16,7 @@ type DB struct {
 }
 
 func New() (*DB, error) {
-	// connStr := createConnectionString(os.Getenv("POSTGRES_USER"), os.Getenv("POSTGRES_PASSWORD"), os.Getenv("POSTGRES_HOST"), os.Getenv("POSTGRES_PORT"), os.Getenv("POSTGRES_DB"))
-	connStr := createConnectionString("nbastatsuser", "nbastatspassword", "localhost", "30001", "nba_stats")
+	connStr := createConnectionString(os.Getenv("POSTGRES_USER"), os.Getenv("POSTGRES_PASSWORD"), os.Getenv("POSTGRES_HOST"), os.Getenv("POSTGRES_PORT"), os.Getenv("POSTGRES_DB"))
 	ctx := context.Background()
 
 	// Create connection pool

--- a/internal/pkg/db/db_test.go
+++ b/internal/pkg/db/db_test.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	tests := []struct {
+		name     string
+		conn     PostgresConn
+		testFunc func(t *testing.T, err error)
+	}{
+		{
+			name: "happy path, no error",
+			conn: mockConn{},
+			testFunc: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "error",
+			conn: mockConn{execErr: errors.New("some error")},
+			testFunc: func(t *testing.T, err error) {
+				assert.Error(t, err)
+			},
+		},
+	}
+	for _, tc := range tests {
+		db := DB{conn: tc.conn}
+		got := db.Init()
+		tc.testFunc(t, got)
+	}
+}
+
+func TestSaveTeam(t *testing.T) {
+	tests := []struct {
+		name     string
+		conn     PostgresConn
+		testFunc func(t *testing.T, err error)
+	}{
+		{
+			name: "happy path, no error",
+			conn: mockConn{},
+			testFunc: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "error",
+			conn: mockConn{execErr: errors.New("some error")},
+			testFunc: func(t *testing.T, err error) {
+				assert.Error(t, err)
+			},
+		},
+	}
+	for _, tc := range tests {
+		db := DB{conn: tc.conn}
+		got := db.SaveTeam(sportsblaze.Team{})
+		tc.testFunc(t, got)
+	}
+}
+
+type mockConn struct {
+	execErr error
+	pingErr error
+}
+
+func (mc mockConn) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, mc.execErr
+}
+
+func (mc mockConn) Ping(ctx context.Context) error {
+	return mc.pingErr
+}

--- a/internal/pkg/db/helpers.go
+++ b/internal/pkg/db/helpers.go
@@ -2,9 +2,24 @@ package db
 
 import (
 	"fmt"
+
+	"github.com/rajwalgautam/nba-stats/internal/pkg/nbautils"
+	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
 )
 
 // createConnectionString creates a connection string for connecting to postgres db
 func createConnectionString(user, password, host, port, dbname string) string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s", user, password, host, port, dbname)
+}
+
+func transformTeamToDBTeam(sbteam sportsblaze.Team) Team {
+	var abbrev string
+	abbrev, ok := nbautils.LookupAbbrev(sbteam.Name)
+	if !ok {
+		abbrev = "XXX"
+	}
+	return Team{
+		FullName:     sbteam.Name,
+		Abbreviation: abbrev,
+	}
 }

--- a/internal/pkg/db/helpers_test.go
+++ b/internal/pkg/db/helpers_test.go
@@ -2,6 +2,9 @@ package db
 
 import (
 	"testing"
+
+	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateConnectionString(t *testing.T) {
@@ -11,5 +14,33 @@ func TestCreateConnectionString(t *testing.T) {
 	want := expectedString
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestTransformTeamToDBTeam(t *testing.T) {
+	tests := []struct {
+		name     string
+		team     sportsblaze.Team
+		testFunc func(t *testing.T, team Team)
+	}{
+		{
+			name: "happy path, abbrev found",
+			team: sportsblaze.Team{Name: "Dallas Mavericks"},
+			testFunc: func(t *testing.T, team Team) {
+				assert.Equal(t, "DAL", team.Abbreviation)
+			},
+		},
+		{
+			name: "abbrev not found",
+			team: sportsblaze.Team{Name: "Some fake team"},
+			testFunc: func(t *testing.T, team Team) {
+				assert.Equal(t, "XXX", team.Abbreviation)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		got := transformTeamToDBTeam(tc.team)
+		tc.testFunc(t, got)
 	}
 }

--- a/internal/pkg/db/models.go
+++ b/internal/pkg/db/models.go
@@ -2,6 +2,6 @@ package db
 
 type Team struct {
 	FullName     string `json:"full_name"`
-	Abbreviation string `json:"abbreviation"` // TODO: add abbreviation validation
+	Abbreviation string `json:"abbreviation"`
 	CityState    string `json:"city_state"`
 }

--- a/internal/pkg/db/models.go
+++ b/internal/pkg/db/models.go
@@ -1,0 +1,7 @@
+package db
+
+type Team struct {
+	FullName     string `json:"full_name"`
+	Abbreviation string `json:"abbreviation"` // TODO: add abbreviation validation
+	CityState    string `json:"city_state"`
+}

--- a/internal/pkg/db/models.go
+++ b/internal/pkg/db/models.go
@@ -3,5 +3,4 @@ package db
 type Team struct {
 	FullName     string `json:"full_name"`
 	Abbreviation string `json:"abbreviation"`
-	CityState    string `json:"city_state"`
 }

--- a/internal/pkg/db/tables.go
+++ b/internal/pkg/db/tables.go
@@ -6,6 +6,10 @@ var (
 	// SQL statements
 	createTableSQL = `create table if not exists %s
 		(key %s primary key, value %s not null);`
+
+	setSql = `
+		insert into %s (key, value) values ($1, $2)
+		on conflict (key) do update set value = EXCLUDED.value;`
 )
 
 // Build the SQL commands to create the tables
@@ -24,25 +28,30 @@ type tableDef struct {
 	valueType string
 }
 
-var tables = []tableDef{
-	{
+var (
+	nbaBoxScoreTable = tableDef{
 		name:      "nba_game_box_scores",
 		keyType:   "text",
 		valueType: "jsonb",
-	},
-	{
+	}
+
+	nbaSpecialtyStatsTable = tableDef{
 		name:      "nba_specialty_stats",
 		keyType:   "text",
 		valueType: "jsonb",
-	},
-	{
+	}
+
+	nbaTeamsTable = tableDef{
 		name:      "nba_teams",
 		keyType:   "text",
 		valueType: "jsonb",
-	},
-	{
+	}
+
+	nbaPlayersTable = tableDef{
 		name:      "nba_players",
 		keyType:   "uuid",
 		valueType: "jsonb",
-	},
-}
+	}
+)
+
+var tables = []tableDef{nbaBoxScoreTable, nbaSpecialtyStatsTable, nbaTeamsTable, nbaPlayersTable}

--- a/internal/pkg/gamestatsjob/gamestatsjob.go
+++ b/internal/pkg/gamestatsjob/gamestatsjob.go
@@ -1,0 +1,77 @@
+package gamestatsjob
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/rajwalgautam/nba-stats/internal/pkg/db"
+	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
+)
+
+var (
+	statsdb     DBClient
+	statsClient SportsblazeClient
+)
+
+func Run() error {
+	err := initDb()
+	if err != nil {
+		return fmt.Errorf("error initializing db: %v", err)
+	}
+	log.Println("db initialized successfully")
+
+	err = initStatsClient()
+	if err != nil {
+		return fmt.Errorf("error initializing stats client: %v", err)
+	}
+	log.Println("stats client initialized successfully")
+
+	// fetch daily box scores
+	date := "2024-10-26" // TODO: make this value dynamic/range over multiple dates
+	dailyBoxScores, err := statsClient.DailyBoxScores(date)
+	if err != nil {
+		return fmt.Errorf("sportsblaze error: %v", err)
+	}
+	log.Printf("got %d games for %s\n", len(dailyBoxScores.Games), date)
+
+	err = handleGames(dailyBoxScores.Games)
+	if err != nil {
+		return fmt.Errorf("error handling games: %v", err)
+	}
+
+	log.Println("game stats job completed successfully")
+	return nil
+}
+
+func initDb() error {
+	var err error
+	statsdb, err = db.New()
+	if err != nil {
+		return fmt.Errorf("db connection err: %v", err)
+	}
+	err = statsdb.Init()
+	if err != nil {
+		return fmt.Errorf("db init err: %v", err)
+	}
+	return nil
+}
+
+func initStatsClient() error {
+	apiKey, ok := os.LookupEnv("SPORTSBLAZE_API_KEY")
+	if !ok {
+		return errors.New("error: sportsblaze api key required")
+	}
+	statsClient = sportsblaze.New(sportsblaze.Options{ApiKey: apiKey})
+	return nil
+}
+
+type SportsblazeClient interface {
+	DailyBoxScores(date string) (*sportsblaze.DailyBoxScores, error)
+}
+
+type DBClient interface {
+	Init() error
+	SaveTeam(team sportsblaze.Team) error
+}

--- a/internal/pkg/gamestatsjob/gamestatsjob.go
+++ b/internal/pkg/gamestatsjob/gamestatsjob.go
@@ -1,33 +1,13 @@
 package gamestatsjob
 
 import (
-	"errors"
 	"fmt"
 	"log"
-	"os"
 
-	"github.com/rajwalgautam/nba-stats/internal/pkg/db"
 	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
 )
 
-var (
-	statsdb     DBClient
-	statsClient SportsblazeClient
-)
-
-func Run() error {
-	err := initDb()
-	if err != nil {
-		return fmt.Errorf("error initializing db: %v", err)
-	}
-	log.Println("db initialized successfully")
-
-	err = initStatsClient()
-	if err != nil {
-		return fmt.Errorf("error initializing stats client: %v", err)
-	}
-	log.Println("stats client initialized successfully")
-
+func Run(storage Storage, statsClient StatsClient) error {
 	// fetch daily box scores
 	date := "2024-10-26" // TODO: make this value dynamic/range over multiple dates
 	dailyBoxScores, err := statsClient.DailyBoxScores(date)
@@ -36,7 +16,7 @@ func Run() error {
 	}
 	log.Printf("got %d games for %s\n", len(dailyBoxScores.Games), date)
 
-	err = handleGames(dailyBoxScores.Games)
+	err = handleGames(dailyBoxScores.Games, storage)
 	if err != nil {
 		return fmt.Errorf("error handling games: %v", err)
 	}
@@ -45,33 +25,10 @@ func Run() error {
 	return nil
 }
 
-func initDb() error {
-	var err error
-	statsdb, err = db.New()
-	if err != nil {
-		return fmt.Errorf("db connection err: %v", err)
-	}
-	err = statsdb.Init()
-	if err != nil {
-		return fmt.Errorf("db init err: %v", err)
-	}
-	return nil
-}
-
-func initStatsClient() error {
-	apiKey, ok := os.LookupEnv("SPORTSBLAZE_API_KEY")
-	if !ok {
-		return errors.New("error: sportsblaze api key required")
-	}
-	statsClient = sportsblaze.New(sportsblaze.Options{ApiKey: apiKey})
-	return nil
-}
-
-type SportsblazeClient interface {
+type StatsClient interface {
 	DailyBoxScores(date string) (*sportsblaze.DailyBoxScores, error)
 }
 
-type DBClient interface {
-	Init() error
+type Storage interface {
 	SaveTeam(team sportsblaze.Team) error
 }

--- a/internal/pkg/gamestatsjob/gamestatsjob_test.go
+++ b/internal/pkg/gamestatsjob/gamestatsjob_test.go
@@ -1,0 +1,56 @@
+package gamestatsjob
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunGameStatsJob(t *testing.T) {
+	tests := []struct {
+		name        string
+		storage     Storage
+		statsClient StatsClient
+		testFunc    func(t *testing.T, err error)
+	}{
+		{
+			name:        "happy path, no error",
+			storage:     mockStorage{},
+			statsClient: mockStatsClient{dailyBoxScoreResp: &sportsblaze.DailyBoxScores{}},
+			testFunc: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name:    "db error",
+			storage: mockStorage{saveErr: errors.New("some db error")},
+			statsClient: mockStatsClient{
+				dailyBoxScoreResp: &sportsblaze.DailyBoxScores{
+					Games: []sportsblaze.Game{{}},
+				},
+			},
+			testFunc: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "some db error")
+			},
+		},
+		{
+			name:    "stats client error",
+			storage: mockStorage{},
+			statsClient: mockStatsClient{
+				dailyBoxScoreResp: &sportsblaze.DailyBoxScores{
+					Games: []sportsblaze.Game{{}},
+				},
+				dailyBoxScoreErr: errors.New("some stats client error"),
+			},
+			testFunc: func(t *testing.T, err error) {
+				assert.ErrorContains(t, err, "some stats client error")
+			},
+		},
+	}
+	for _, tc := range tests {
+		got := Run(tc.storage, tc.statsClient)
+		tc.testFunc(t, got)
+	}
+}

--- a/internal/pkg/gamestatsjob/handlers.go
+++ b/internal/pkg/gamestatsjob/handlers.go
@@ -1,0 +1,58 @@
+package gamestatsjob
+
+import (
+	"sync"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
+)
+
+func handleGames(games []sportsblaze.Game) error {
+	var wg sync.WaitGroup
+	wg.Add(len(games))
+
+	var me error
+	for _, game := range games {
+		// concurrently handle each game
+		go func() {
+			defer wg.Done()
+			err := processGame(game)
+			if err != nil {
+				me = multierror.Append(me, err)
+			}
+		}()
+	}
+	// wait for all games to get processed
+	wg.Wait()
+	return me
+}
+
+func processGame(game sportsblaze.Game) error {
+	var err, errTeam error
+	var wg sync.WaitGroup
+
+	// concurrently handle saving to each table with wg.Go()
+	// handle teams
+	wg.Go(func() {
+		err := statsdb.SaveTeam(game.Teams.Home)
+		if err != nil {
+			errTeam = multierror.Append(errTeam, err)
+		}
+		err = statsdb.SaveTeam(game.Teams.Away)
+		if err != nil {
+			errTeam = multierror.Append(errTeam, err)
+		}
+	})
+
+	// TODO: add wg.Go() for other stats processing
+
+	wg.Wait()
+
+	// aggregate errors
+	// TODO: add errors from other stats processing
+	if errTeam != nil {
+		err = multierror.Append(err, errTeam)
+	}
+
+	return err
+}

--- a/internal/pkg/gamestatsjob/handlers.go
+++ b/internal/pkg/gamestatsjob/handlers.go
@@ -7,46 +7,32 @@ import (
 	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
 )
 
-func handleGames(games []sportsblaze.Game) error {
+func handleGames(games []sportsblaze.Game, storage Storage) error {
 	var wg sync.WaitGroup
 	wg.Add(len(games))
 
 	var me error
 	for _, game := range games {
-		// concurrently handle each game
-		go func() {
-			defer wg.Done()
-			err := processGame(game)
-			if err != nil {
-				me = multierror.Append(me, err)
-			}
-		}()
+		err := processGame(game, storage)
+		if err != nil {
+			me = multierror.Append(me, err)
+		}
 	}
-	// wait for all games to get processed
-	wg.Wait()
 	return me
 }
 
-func processGame(game sportsblaze.Game) error {
+func processGame(game sportsblaze.Game, storage Storage) error {
 	var err, errTeam error
-	var wg sync.WaitGroup
 
-	// concurrently handle saving to each table with wg.Go()
 	// handle teams
-	wg.Go(func() {
-		err := statsdb.SaveTeam(game.Teams.Home)
-		if err != nil {
-			errTeam = multierror.Append(errTeam, err)
-		}
-		err = statsdb.SaveTeam(game.Teams.Away)
-		if err != nil {
-			errTeam = multierror.Append(errTeam, err)
-		}
-	})
-
-	// TODO: add wg.Go() for other stats processing
-
-	wg.Wait()
+	err = storage.SaveTeam(game.Teams.Home)
+	if err != nil {
+		errTeam = multierror.Append(errTeam, err)
+	}
+	err = storage.SaveTeam(game.Teams.Away)
+	if err != nil {
+		errTeam = multierror.Append(errTeam, err)
+	}
 
 	// aggregate errors
 	// TODO: add errors from other stats processing

--- a/internal/pkg/gamestatsjob/handlers.go
+++ b/internal/pkg/gamestatsjob/handlers.go
@@ -1,16 +1,11 @@
 package gamestatsjob
 
 import (
-	"sync"
-
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
 )
 
 func handleGames(games []sportsblaze.Game, storage Storage) error {
-	var wg sync.WaitGroup
-	wg.Add(len(games))
-
 	var me error
 	for _, game := range games {
 		err := processGame(game, storage)
@@ -22,23 +17,19 @@ func handleGames(games []sportsblaze.Game, storage Storage) error {
 }
 
 func processGame(game sportsblaze.Game, storage Storage) error {
-	var err, errTeam error
-
 	// handle teams
-	err = storage.SaveTeam(game.Teams.Home)
+	err := storage.SaveTeam(game.Teams.Home)
 	if err != nil {
-		errTeam = multierror.Append(errTeam, err)
+		return err
 	}
 	err = storage.SaveTeam(game.Teams.Away)
 	if err != nil {
-		errTeam = multierror.Append(errTeam, err)
+		return err
 	}
 
-	// aggregate errors
-	// TODO: add errors from other stats processing
-	if errTeam != nil {
-		err = multierror.Append(err, errTeam)
-	}
+	// handle box score stats
 
-	return err
+	// handle player stats
+
+	return nil
 }

--- a/internal/pkg/gamestatsjob/handlers_test.go
+++ b/internal/pkg/gamestatsjob/handlers_test.go
@@ -1,0 +1,71 @@
+package gamestatsjob
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessGame(t *testing.T) {
+	tests := []struct {
+		name     string
+		game     sportsblaze.Game
+		storage  mockStorage
+		prep     func()
+		testFunc func(t *testing.T, err error)
+	}{
+		{
+			name:    "happy path, no error",
+			game:    sportsblaze.Game{ID: "id1"},
+			storage: mockStorage{},
+			testFunc: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name:    "some db save error",
+			storage: mockStorage{saveErr: errors.New("some error")},
+			game:    sportsblaze.Game{ID: "id1"},
+			testFunc: func(t *testing.T, err error) {
+				assert.Error(t, err)
+			},
+		},
+	}
+	for _, tc := range tests {
+		got := processGame(tc.game, tc.storage)
+		tc.testFunc(t, got)
+	}
+}
+
+func TestHandleGames(t *testing.T) {
+	tests := []struct {
+		name     string
+		games    []sportsblaze.Game
+		storage  mockStorage
+		prep     func()
+		testFunc func(t *testing.T, err error)
+	}{
+		{
+			name:    "happy path, no error",
+			games:   []sportsblaze.Game{{ID: "id1"}},
+			storage: mockStorage{},
+			testFunc: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name:    "some db save error",
+			storage: mockStorage{saveErr: errors.New("some error")},
+			games:   []sportsblaze.Game{{ID: "id1"}},
+			testFunc: func(t *testing.T, err error) {
+				assert.Error(t, err)
+			},
+		},
+	}
+	for _, tc := range tests {
+		got := handleGames(tc.games, tc.storage)
+		tc.testFunc(t, got)
+	}
+}

--- a/internal/pkg/gamestatsjob/mocks.go
+++ b/internal/pkg/gamestatsjob/mocks.go
@@ -1,0 +1,20 @@
+package gamestatsjob
+
+import "github.com/rajwalgautam/nba-stats/internal/pkg/sportsblaze"
+
+type mockStorage struct {
+	saveErr error
+}
+
+func (ms mockStorage) SaveTeam(sportsblaze.Team) error {
+	return ms.saveErr
+}
+
+type mockStatsClient struct {
+	dailyBoxScoreResp *sportsblaze.DailyBoxScores
+	dailyBoxScoreErr  error
+}
+
+func (msc mockStatsClient) DailyBoxScores(date string) (*sportsblaze.DailyBoxScores, error) {
+	return msc.dailyBoxScoreResp, msc.dailyBoxScoreErr
+}

--- a/internal/pkg/nbautils/constants.go
+++ b/internal/pkg/nbautils/constants.go
@@ -1,0 +1,39 @@
+package nbautils
+
+var NbaTeamsAbbreviations = map[string]string{
+	"Atlanta Hawks":          "ATL",
+	"Boston Celtics":         "BOS",
+	"Brooklyn Nets":          "BKN",
+	"Charlotte Hornets":      "CHA",
+	"Chicago Bulls":          "CHI",
+	"Cleveland Cavaliers":    "CLE",
+	"Dallas Mavericks":       "DAL",
+	"Denver Nuggets":         "DEN",
+	"Detroit Pistons":        "DET",
+	"Golden State Warriors":  "GSW",
+	"Houston Rockets":        "HOU",
+	"Indiana Pacers":         "IND",
+	"Los Angeles Clippers":   "LAC",
+	"Los Angeles Lakers":     "LAL",
+	"Memphis Grizzlies":      "MEM",
+	"Miami Heat":             "MIA",
+	"Milwaukee Bucks":        "MIL",
+	"Minnesota Timberwolves": "MIN",
+	"New Orleans Pelicans":   "NOP",
+	"New York Knicks":        "NYK",
+	"Oklahoma City Thunder":  "OKC",
+	"Orlando Magic":          "ORL",
+	"Philadelphia 76ers":     "PHI",
+	"Phoenix Suns":           "PHX",
+	"Portland Trail Blazers": "POR",
+	"Sacramento Kings":       "SAC",
+	"San Antonio Spurs":      "SAS",
+	"Toronto Raptors":        "TOR",
+	"Utah Jazz":              "UTA",
+	"Washington Wizards":     "WAS",
+}
+
+func LookupAbbrev(key string) (string, bool) {
+	val, ok := NbaTeamsAbbreviations[key]
+	return val, ok
+}

--- a/internal/pkg/nbautils/constants.go
+++ b/internal/pkg/nbautils/constants.go
@@ -13,7 +13,7 @@ var NbaTeamsAbbreviations = map[string]string{
 	"Golden State Warriors":  "GSW",
 	"Houston Rockets":        "HOU",
 	"Indiana Pacers":         "IND",
-	"Los Angeles Clippers":   "LAC",
+	"LA Clippers":            "LAC",
 	"Los Angeles Lakers":     "LAL",
 	"Memphis Grizzlies":      "MEM",
 	"Miami Heat":             "MIA",

--- a/internal/pkg/sportsblaze/sportsblaze.go
+++ b/internal/pkg/sportsblaze/sportsblaze.go
@@ -61,11 +61,11 @@ func (c *Client) DailyBoxScores(date string) (*DailyBoxScores, error) {
 }
 
 func (c *Client) get(path string) ([]byte, error) {
-	withKey, err := c.addApiKey(path)
+	urlWithKey, err := c.addApiKey(path)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.httpc.Get(withKey)
+	resp, err := c.httpc.Get(urlWithKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is just a draft. 

* Move bulk of gamestatsjob to separate pkg so that `/cmd/gamestatsjob` just acts as an entrypoint
* Add scaffolding for processing box score data, make db connection + sportsblaze client global vars
* Add logic to save teams
* Use "accept interfaces, return structs" approach for db connection + sportsblaze client to facilitate testing 
* Update db table vars, add upsert sql 